### PR TITLE
debian: Update notification now notifies dom0 when an upgrade is complet...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ install-deb:
 	install -D -m 644 misc/qubes-archive-keyring.gpg $(DESTDIR)/etc/apt/trusted.gpg.d/qubes-archive-keyring.gpg
 	install -D -m 644 network/iptables $(DESTDIR)/etc/iptables/rules.v4
 	install -D -m 644 network/ip6tables $(DESTDIR)/etc/iptables/rules.v6
+	install -D -m 644 network/00notiy-hook $(DESTDIR)/etc/apt/apt.conf.d/00notiy-hook
 	install -d $(DESTDIR)/etc/sysctl.d
 	install -m 644 network/80-qubes.conf $(DESTDIR)/etc/sysctl.d/
 	install -D -m 644 misc/profile.d_qt_x11_no_mitshm.sh $(DESTDIR)/etc/profile.d/qt_x11_no_mitshm.sh

--- a/network/00notiy-hook
+++ b/network/00notiy-hook
@@ -1,0 +1,2 @@
+#DPkg::Post-Invoke {"echo 'invoked' >> /tmp/apt-post-invoke; systemctl start qubes-update-check.service";};
+DPkg::Post-Invoke {"systemctl start qubes-update-check.service";};

--- a/vm-systemd/qubes-update-check.service
+++ b/vm-systemd/qubes-update-check.service
@@ -4,4 +4,4 @@ ConditionPathExists=/var/run/qubes-service/qubes-update-check
 
 [Service]
 Type=oneshot
-ExecStart=/usr/lib/qubes/qrexec-client-vm dom0 qubes.NotifyUpdates /bin/sh -c 'if [ -e /usr/bin/yum ]; then yum -q check-update >/dev/null; [ $? -eq 100 ] && echo 1 || echo 0; else apt-get -q update > /dev/null; apt-get -s upgrade | awk "/^Inst/{ print $2 }" | [ $(wc -L) -eq 0 ] && echo 0 || echo 1; fi'
+ExecStart=/usr/lib/qubes/qrexec-client-vm dom0 qubes.NotifyUpdates /bin/sh -c 'if [ -e /etc/system-release ]; then yum -q check-update >/dev/null; [ $? -eq 100 ] && echo 1 || echo 0; else apt-get -q update > /dev/null; apt-get -s upgrade | awk "/^Inst/{ print $2 }" | [ $(wc -L) -eq 0 ] && echo 0 || echo 1; fi'


### PR DESCRIPTION
...ed

This seems to do the job to notify dom0 after an `upgrade` has been completed.  I left a piece of commented out debug code in `/etc/apt/apt-conf.d/00notify-hook` that just writes `invoked` to a tmp file to indicate how many time that hook was called.  So far it appears to have only been called once after the update, but I left it in there so it will be easy to debug it.

I also changed the condition to identify Fedora compared to Debian in ` vm-systemd/qubes-update-check.service` since it used to look `yum`, but since yum is not included that would not work so I instead am using `/etc/system-release` which does not exist in Debian.