### PR TITLE
debian: Only notify dom0 on apt-get post hook; don't update package inde...

### DIFF
--- a/network/00notiy-hook
+++ b/network/00notiy-hook
@@ -1,2 +1,1 @@
-#DPkg::Post-Invoke {"echo 'invoked' >> /tmp/apt-post-invoke; systemctl start qubes-update-check.service";};
-DPkg::Post-Invoke {"systemctl start qubes-update-check.service";};
+DPkg::Post-Invoke {"/usr/lib/qubes/qrexec-client-vm dom0 qubes.NotifyUpdates /bin/sh -c 'echo 0'";};

--- a/network/00notiy-hook
+++ b/network/00notiy-hook
@@ -1,1 +1,1 @@
-DPkg::Post-Invoke {"/usr/lib/qubes/qrexec-client-vm dom0 qubes.NotifyUpdates /bin/sh -c 'echo 0'";};
+DPkg::Post-Invoke {"/usr/lib/qubes/qrexec-client-vm dom0 qubes.NotifyUpdates /bin/sh -c 'echo 0' || true";};


### PR DESCRIPTION
...x

There is a possiblilty of the apt-get post hook getting triggered
more than once for each apt-get session, therefore we only notify
dom0 that there are no updates available and do not perform an
apt-get update.

The qubes-update-check.service will still perform an update so even
if the dist-upgrade failed and there was actually more files to update
the qubes-update-check.serivce would then at some point notify dom0
about those updates being available