### PR TITLE
added pulseaudio-kde and spice-vdagent to qubes-trigger-desktop-file-install

### DIFF
--- a/misc/qubes-trigger-desktop-file-install
+++ b/misc/qubes-trigger-desktop-file-install
@@ -53,11 +53,13 @@ install () {
 # Desktop Entry Modification - NotShowIn=QUBES
 FILES=(
     'pulseaudio'
+    'pulseaudio-kde'
     'deja-dup-monitor'
     'imsettings-start'
     'krb5-auth-dialog'
     'restorecond'
     'sealertauto'
+    'spice-vdagent'
     'gnome-power-manager'
     'gnome-sound-applet'
     'gnome-screensaver'


### PR DESCRIPTION
So those can be removed from https://github.com/adrelanos/qubes-whonix/blob/master/debian/qubes-whonix.postinst.

I managed to remove most `showIn` from `qubes-whonix.postinst` by making these modifications unnecessary, by making these modifications the default in Whonix's code. What's left is `/etc/xdg/autostart/pulseaudio-kde.desktop` and `/etc/xdg/autostart/spice-vdagent.desktop`.

If these could be added in qubes-core-agent-linux postinst, then qubes-whonix.postinst would not need to be ported to qubes-trigger-desktop-file-install.

Do you think adding pulseaudio-kde and spice-vdagent to qubes-core-agent-linux's qubes-trigger-desktop-file-install is appropriate?

spice-vdagent doesn't matter a lot. It was installed by default for Qubes-Whonix 9. Was fixed in Whonix 10. That file could still be around on Qubes-Whonix that upgraded, but not for new installations. Not disabling it is not a big deal. spice-vdagent won't start anyhow if KVM isn't detected.

I am not sure about pulseaudio-kde. I don't know yet why stuff like /etc/xdg/autostart/pulseaudio.desktop gets disabled in Qubes to begin with. Neither I have an explanation @nrgaway specifically only disabled /etc/xdg/autostart/pulseaudio-kde.desktop in Qubes-Whonix only.