### PR TITLE
Allow passwordless login for user "user" (when using 'sudo xl console').

### DIFF
--- a/debian/qubes-core-agent.preinst
+++ b/debian/qubes-core-agent.preinst
@@ -44,7 +44,7 @@ if [ "$1" = "install" ] ; then
     # User add / modifications
     # --------------------------------------------------------------------------
     id -u 'user' >/dev/null 2>&1 || {
-        useradd --user-group --create-home --shell /bin/bash user
+        useradd --password "" --user-group --create-home --shell /bin/bash user
     }
     id -u 'tinyproxy' >/dev/null 2>&1 || {
         useradd --user-group --system -M --home /run/tinyproxy --shell /bin/false tinyproxy


### PR DESCRIPTION
Fixes https://github.com/QubesOS/qubes-issues/issues/1130.