### PR TITLE
show error msg if qubes.ReceiveUpdates failed

### DIFF
--- a/misc/qubes-download-dom0-updates.sh
+++ b/misc/qubes-download-dom0-updates.sh
@@ -129,7 +129,13 @@ else
 fi
 
 if ls $DOM0_UPDATES_DIR/packages/*.rpm > /dev/null 2>&1; then
-    /usr/lib/qubes/qrexec-client-vm dom0 qubes.ReceiveUpdates /usr/lib/qubes/qfile-agent $DOM0_UPDATES_DIR/packages/*.rpm
+    cmd="/usr/lib/qubes/qrexec-client-vm dom0 qubes.ReceiveUpdates /usr/lib/qubes/qfile-agent"
+    qrexec_exit_code=0
+    $cmd $DOM0_UPDATES_DIR/packages/*.rpm || { qrexec_exit_code=$? ; true; };
+    if [ ! "$qrexec_exit_code" = "0" ]; then
+        echo "'$cmd $DOM0_UPDATES_DIR/packages/*.rpm' failed with exit code ${qrexec_exit_code}!" >&2
+        exit $qrexec_exit_code
+    fi
 else
     echo "No packages downloaded"
 fi


### PR DESCRIPTION
As long as qrexec doesn't run really "round and flawless" (ex: https://github.com/QubesOS/qubes-issues/issues/1148 and perhaps others), as of now, `qubes-dom0-update` fails very non-obviously. Just exits non-zero without informing the user, that there is a problem. This pull requests implements a better output in case of failing.