### PR TITLE
Fix broken temporary file deletion in qubes.GetImageRGBA

### DIFF
--- a/qubes-rpc/qubes.GetImageRGBA
+++ b/qubes-rpc/qubes.GetImageRGBA
@@ -21,10 +21,10 @@ elif [ "${filename}" = "-" ] || [ "${filename##*:}" = "-" ]; then
     tmpfile="$(mktemp /tmp/qimg-XXXXXXXX)"
     cat > "${tmpfile}"
     if [ "${filename##*:}" = "-" ]; then
-        tmpfile="${filename%:*}:${tmpfile}"
+        filename="${filename%:*}:${tmpfile}"
+    else
+        filename="${tmpfile}"
     fi
-    filename="${tmpfile}"
-
 elif ! [ -r "${filename}" ]; then
     exit 1
 fi
@@ -34,6 +34,6 @@ fi
 identify -format '%w %h\n' "$filename" | sed -e '/^$/d'
 convert -depth 8 "$filename" rgba:-
 
-[ -n "${tmpfile}" ] && rm -f ${tmpfile} || true
+[ -n "${tmpfile}" ] && rm -f "${tmpfile}" || true
 
 # vim: ft=sh ts=4 sw=4 et


### PR DESCRIPTION
The code mistakenly set the tmpfile variable to the convert argument rather than the file breaking deletion and also was missing quotes around the use of ${tmpfile} in rm -f

BTW if this is only used for getting app icons, I'm not sure why the caller needs to be allowed to specify arbitrary input data and an arbitrary conversion delegate.
