### PR TITLE
added missing dependency python-dbus to 'Depends:'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,6 +27,7 @@ Depends:
     python2.7,
     python-gi,
     python-xdg,
+    python-dbus,
     qubes-utils (>= 3.0.1),
     sudo,
     systemd,


### PR DESCRIPTION
https://github.com/marmarek/qubes-core-agent-linux/blob/master/misc/qubes-desktop-run depends on python-dbus.
(https://github.com/marmarek/qubes-core-agent-linux/blob/0b7ade11b868babe44c73e1a502cdd44487abac9/misc/xdg.py#L5)