### PR TITLE
Fix icon selection using pyxdg and support SVG icons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ install-common:
 	install qubes-rpc/qvm-copy-to-vm.gnome $(DESTDIR)$(LIBDIR)/qubes
 	install qubes-rpc/qvm-move-to-vm.kde $(DESTDIR)$(LIBDIR)/qubes
 	install qubes-rpc/qvm-move-to-vm.gnome $(DESTDIR)$(LIBDIR)/qubes
+	install qubes-rpc/xdg-icon $(DESTDIR)$(LIBDIR)/qubes
 	install qubes-rpc/{vm-file-editor,qfile-agent,qopen-in-vm} $(DESTDIR)$(LIBDIR)/qubes
 	install qubes-rpc/tar2qfile $(DESTDIR)$(LIBDIR)/qubes
 	# Install qfile-unpacker as SUID - because it will fail to receive files from other vm

--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Depends:
     initscripts,
     iptables,
     iptables-persistent,
+    librsvg2-bin,
     libvchan-xen,
     locales,
     ncurses-term,

--- a/qubes-rpc/qubes.GetImageRGBA
+++ b/qubes-rpc/qubes.GetImageRGBA
@@ -21,10 +21,10 @@ elif [ "${filename}" = "-" ] || [ "${filename##*:}" = "-" ]; then
     tmpfile="$(mktemp /tmp/qimg-XXXXXXXX)"
     cat > "${tmpfile}"
     if [ "${filename##*:}" = "-" ]; then
-        tmpfile="${filename%:*}:${tmpfile}"
+        filename="${filename%:*}:${tmpfile}"
+    else
+        filename="${tmpfile}"
     fi
-    filename="${tmpfile}"
-
 elif ! [ -r "${filename}" ]; then
     exit 1
 fi
@@ -34,6 +34,6 @@ fi
 identify -format '%w %h\n' "$filename" | sed -e '/^$/d'
 convert -depth 8 "$filename" rgba:-
 
-[ -n "${tmpfile}" ] && rm -f ${tmpfile} || true
+[ -n "${tmpfile}" ] && rm -f "${tmpfile}" || true
 
 # vim: ft=sh ts=4 sw=4 et

--- a/qubes-rpc/qubes.GetImageRGBA
+++ b/qubes-rpc/qubes.GetImageRGBA
@@ -1,22 +1,13 @@
 set -e
 read filename
 
+ICON_MAXSIZE=512
+
 if [ "${filename%%:*}" = xdgicon ]; then
-    # get biggest icon from hicolor theme
+    filename="$(/usr/lib/qubes/xdg-icon "${filename#*:}" "$ICON_MAXSIZE")"
+    forcesize="$ICON_MAXSIZE"
 
-    filename="${filename#*:}.png"
-    candidate=
-    for dir in /usr/share/icons/hicolor/ /usr/share/icons/; do
-        candidate=$(find -L "${dir}" -type f -name "${filename}")
-        if [ -n "${candidate}" ]; then
-            candidate=$(echo "${candidate}" | xargs ls --sort=size | head -1)
-            break
-        fi
-    done
-
-    [ -n "${candidate}" ]
-    filename="${candidate}"
-
+    [ -n "${filename}" ]
 elif [ "${filename}" = "-" ] || [ "${filename##*:}" = "-" ]; then
     tmpfile="$(mktemp /tmp/qimg-XXXXXXXX)"
     cat > "${tmpfile}"
@@ -29,11 +20,23 @@ elif ! [ -r "${filename}" ]; then
     exit 1
 fi
 
-# identify in F18 (6.7) adds implicit '\n' to format,
-# whereas identify in F20 (6.8) does not
-identify -format '%w %h\n' "$filename" | sed -e '/^$/d'
-convert -depth 8 "$filename" rgba:-
+s="$(identify -format '%w %h %m' "$filename")"
+w="$(echo "$s"|cut -d " " -f 1)"
+h="$(echo "$s"|cut -d " " -f 2)"
+m="$(echo "$s"|cut -d " " -f 3)"
+if [ "$m" = SVG ]; then
+    if [ -n "$forcesize" ]; then
+        w="$forcesize"
+        h="$forcesize"
+    fi
+    tmpfile2="$(mktemp /tmp/qimg-XXXXXXXX.png)"
+    rsvg-convert -w "$w" -h "$h" -o "$tmpfile2" "$filename"
+    filename="$tmpfile2"
+fi
+echo "$w $h"
+convert -depth 8 -size "${w}x${h}" "$filename" rgba:-
 
 [ -n "${tmpfile}" ] && rm -f "${tmpfile}" || true
+[ -n "${tmpfile2}" ] && rm -f "${tmpfile2}" || true
 
 # vim: ft=sh ts=4 sw=4 et

--- a/qubes-rpc/xdg-icon
+++ b/qubes-rpc/xdg-icon
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+import xdg.IconTheme
+import sys
+import os
+
+themes = ['Humanity', 'Adwaita', 'gnome', 'oxygen']
+themes = themes + sorted([d for d in os.listdir("/usr/share/icons") if d not in themes and os.path.isdir("/usr/share/icons/" + d)])
+
+if len(sys.argv) < 3:
+	print "Usage:", sys.argv[0], "ICON SIZE"
+	sys.exit(1)
+
+for theme in themes:
+	icon = xdg.IconTheme.getIconPath(sys.argv[1], theme = theme, size = int(sys.argv[2]))
+	if icon is not None:
+		break
+
+if icon is None:
+	sys.exit(1)
+
+print icon

--- a/rpm_spec/core-vm.spec
+++ b/rpm_spec/core-vm.spec
@@ -51,13 +51,14 @@ Requires:   qubes-utils
 Requires:   initscripts
 # for qubes-desktop-run
 Requires:   pygobject3-base
-# for qubes-session-autostart
+# for qubes-session-autostart, xdg-icon
 Requires:   pyxdg
 %if %{fedora} >= 20
 # gpk-update-viewer required by qubes-manager
 Requires:   gnome-packagekit-updater
 %endif
 Requires:   ImageMagick
+Requires:   librsvg2-tools
 Requires:   fakeroot
 Requires:   desktop-notification-daemon
 Requires:   pygtk2
@@ -410,6 +411,7 @@ rm -f %{name}-%{version}
 /usr/lib/qubes/wrap-in-html-if-url.sh
 /usr/lib/qubes/iptables-updates-proxy
 /usr/lib/qubes/close-window
+/usr/lib/qubes/xdg-icon
 /usr/lib/yum-plugins/yum-qubes-hooks.py*
 /usr/lib64/python2.7/site-packages/qubes/xdg.py*
 /usr/sbin/qubes-firewall


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#1170 and QubesOS/qubes-issues#1171

Uses PyXDG to implement the proper xdg icon selection algorithm.

Calls rsvg-convert for SVG since ImageMagick appears to have some sort of native SVG support but it seems to be broken, failing on some icons.

Renders SVG icons at 512x512 since that's the maximum size the current dom0 code accepts. Maybe it should be reduced, although high resolutions could be needed for desktop or panel usage and dom0 compresses to PNG anyway.

Did basic testing on Fedora and Ubuntu templates.
