### PR TITLE
fixed 'Debian 8 apt.config.d misconfiguration'

### DIFF
--- a/vm-systemd/misc-post.sh
+++ b/vm-systemd/misc-post.sh
@@ -2,7 +2,7 @@
 
 if [ -f /var/run/qubes-service/yum-proxy-setup -o -f /var/run/qubes-service/updates-proxy-setup ]; then
     if [ -d /etc/apt/apt.conf.d ]; then
-        echo 'Acquire::http::Proxy "http://10.137.255.254:8082/";' >> /etc/apt/apt.conf.d/01qubes-proxy
+        echo 'Acquire::http::Proxy "http://10.137.255.254:8082/";' > /etc/apt/apt.conf.d/01qubes-proxy
     fi
     if [ -d /etc/yum.conf.d ]; then
         echo proxy=http://10.137.255.254:8082/ > /etc/yum.conf.d/qubes-proxy.conf


### PR DESCRIPTION
prevent the Acquire::http::Proxy setting ending up multiple times inside /etc/apt/apt.conf.d/01qubes-proxy
(reported by @Scinawa)
https://github.com/QubesOS/qubes-issues/issues/1186
