### PR TITLE
Improved upgrade notifications sent to QVMM.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,9 @@ install-common:
 	install misc/dispvm-prerun.sh $(DESTDIR)$(LIBDIR)/qubes/dispvm-prerun.sh
 	install misc/close-window $(DESTDIR)$(LIBDIR)/qubes/close-window
 
+	install misc/upgrades-installed-check $(DESTDIR)$(LIBDIR)/qubes/upgrades-installed-check
+	install misc/upgrades-status-notify $(DESTDIR)$(LIBDIR)/qubes/upgrades-status-notify
+
 	install -m 0644 network/udev-qubes-network.rules $(DESTDIR)/etc/udev/rules.d/99-qubes-network.rules
 	install network/qubes-setup-dnat-to-ns $(DESTDIR)$(LIBDIR)/qubes
 	install network/setup-ip $(DESTDIR)$(LIBDIR)/qubes/

--- a/misc/upgrades-installed-check
+++ b/misc/upgrades-installed-check
@@ -11,7 +11,8 @@ if [ -e /etc/system-release ]; then
    ## Fedora
    yum_output="$(yum -q check-update 2>&1)"
    exit_code="$?"
-   [ "$exit_code" -eq 100 ] && echo "true" || echo "false"
+   [ "$exit_code" -eq 100 ] && echo "false" && exit 0
+   [ "$exit_code" -eq 0 ] && echo "true"
 else
    ## Debian
    apt_get_output="$(LANG="C" apt-get -s upgrade 2>&1)"

--- a/misc/upgrades-installed-check
+++ b/misc/upgrades-installed-check
@@ -15,6 +15,8 @@ if [ -e /etc/system-release ]; then
    [ "$exit_code" -eq 0 ] && echo "true"
 else
    ## Debian
+   set -e
+   set -o pipefail
    apt_get_output="$(LANG="C" apt-get -s upgrade 2>&1)"
    exit_code="$?"
    echo "$apt_get_output" | awk "/^Inst/{ print $2 }" | [ "$(wc -L)" -eq 0 ] && echo "true" || echo "false"

--- a/misc/upgrades-installed-check
+++ b/misc/upgrades-installed-check
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+## `echo`s:
+## * 'true' - if all upgrades have been installed
+## * 'false' - if there are pending upgrades
+## * nothing - if apt-get is currently locked
+##
+## Forwards the exit code of the package manager.
+
+if [ -e /etc/system-release ]; then
+   ## Fedora
+   yum_output="$(yum -q check-update 2>&1)"
+   exit_code="$?"
+   [ "$exit_code" -eq 100 ] && echo "true" || echo "false"
+else
+   ## Debian
+   apt_get_output="$(LANG="C" apt-get -s upgrade 2>&1)"
+   exit_code="$?"
+   echo "$apt_get_output" | awk "/^Inst/{ print $2 }" | [ "$(wc -L)" -eq 0 ] && echo "true" || echo "false"
+fi
+
+exit "$exit_code"

--- a/misc/upgrades-status-notify
+++ b/misc/upgrades-status-notify
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+upgrades_installed="$(/usr/lib/qubes/upgrades-installed-check 2>&1)"
+
+if [ "$upgrades_installed" = "true" ]; then
+   /usr/lib/qubes/qrexec-client-vm dom0 qubes.NotifyUpdates /bin/sh -c 'echo 0'
+elif [ "$upgrades_installed" = "false" ]; then
+   /usr/lib/qubes/qrexec-client-vm dom0 qubes.NotifyUpdates /bin/sh -c 'echo 1'
+fi

--- a/network/00notify-hook
+++ b/network/00notify-hook
@@ -1,1 +1,1 @@
-DPkg::Post-Invoke {"/usr/lib/qubes/qrexec-client-vm dom0 qubes.NotifyUpdates /bin/sh -c 'echo 0' || true";};
+DPkg::Post-Invoke {"/usr/lib/qubes/upgrades-status-notify || true";};


### PR DESCRIPTION
Each time some arbitrary package was installed using dpkg or apt-get, the update notification in Qubes VM Manager was cleared.
No matter if there were still updates pending. (Could happen even after the user running `apt-get dist-upgrade` in case of package manager issues.)
No longer clear upgrade notification in QVMM on arbitrary package installation.
Check if upgrades have been actually installed before clearing the notifications.

https://github.com/QubesOS/qubes-issues/issues/1066#issuecomment-150044906