### PR TITLE
cleanup /etc/apt/apt.conf.d/00notiy-hook on existing systems

### DIFF
--- a/debian/qubes-core-agent.maintscript
+++ b/debian/qubes-core-agent.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/apt/apt.conf.d/00notiy-hook


### PR DESCRIPTION
00notiy-hook was renamed to 00notify-hook in
'debian: Renamed incorrect filename: 00notiy-hook -> 00notify-hook'
https://github.com/QubesOS/qubes-core-agent-linux/commit/15f1df49474368510180c8b232a69c2a5dce9533
but the old file was not removed.
(Files in /etc do not automatically get removed on Debian systems when these are removed from the package.)

This is an independent, but supporting fix for:
'Improved upgrade notifications sent to QVMM.'
- https://github.com/marmarek/qubes-core-agent-linux/pull/39
- https://github.com/QubesOS/qubes-issues/issues/1066#issuecomment-150044906

Added debian/qubes-core-agent.maintscript.