### PR TITLE
Implementing systemd user dropins and addin dropins for recent cups and pulseaudio packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ DROPIN_DIR ?= "lib/systemd/system"
 DROPINS := chronyd.service crond.service cups.service cups.path cups.socket ModemManager.service
 DROPINS += NetworkManager.service NetworkManager-wait-online.service ntpd.service getty@tty.service
 DROPINS += tmp.mount
+DROPINS += org.cups.cupsd.service org.cups.cupsd.path org.cups.cupsd.socket 
 
 # Debian Dropins
 ifeq ($(shell lsb_release -is), Debian)

--- a/Makefile
+++ b/Makefile
@@ -45,34 +45,35 @@ all:
 	make -C qubes-rpc
 
 # Dropin Directory
-DROPIN_DIR ?= "lib/systemd/system"
+DROPIN_DIR ?= "lib/systemd"
 
-# Fedora Dropins
-DROPINS := chronyd.service crond.service cups.service cups.path cups.socket ModemManager.service
-DROPINS += NetworkManager.service NetworkManager-wait-online.service ntpd.service getty@tty.service
-DROPINS += tmp.mount
-DROPINS += org.cups.cupsd.service org.cups.cupsd.path org.cups.cupsd.socket 
+# Fedora System Dropins
+SYSTEM_DROPINS := chronyd.service crond.service cups.service cups.path cups.socket ModemManager.service
+SYSTEM_DROPINS += NetworkManager.service NetworkManager-wait-online.service ntpd.service getty@tty.service
+SYSTEM_DROPINS += tmp.mount
+SYSTEM_DROPINS += org.cups.cupsd.service org.cups.cupsd.path org.cups.cupsd.socket 
 
-# Debian Dropins
+# Debian System Dropins
 ifeq ($(shell lsb_release -is), Debian)
     # Don't have 'ntpd' in Debian
-    DROPINS := $(filter-out ntpd.service, $(DROPINS))
+    SYSTEM_DROPINS := $(filter-out ntpd.service, $(SYSTEM_DROPINS))
 
     # 'crond.service' is named 'cron.service in Debian
-    DROPINS := $(strip $(patsubst crond.service, cron.service, $(DROPINS)))
+    SYSTEM_DROPINS := $(strip $(patsubst crond.service, cron.service, $(SYSTEM_DROPINS)))
 
-    # Wheezy Dropins
+    # Wheezy System Dropins
     # Disable sysinit 'network-manager.service' since systemd 'NetworkManager.service' is already installed
-    DROPINS += $(strip $(if $(filter wheezy, $(shell lsb_release -cs)), network-manager.service,))
+    SYSTEM_DROPINS += $(strip $(if $(filter wheezy, $(shell lsb_release -cs)), network-manager.service,))
 
 	# handled by qubes-iptables service now
-    DROPINS += netfilter-persistent.service
+    SYSTEM_DROPINS += netfilter-persistent.service
 endif
 
 install-systemd-dropins:
-	@for dropin in $(DROPINS); do \
-	    install -d $(DESTDIR)/$(DROPIN_DIR)/$${dropin}.d ;\
-	    install -m 0644 vm-systemd/$${dropin}.d/*.conf $(DESTDIR)/$(DROPIN_DIR)/$${dropin}.d/ ;\
+	# Install system dropins
+	@for dropin in $(SYSTEM_DROPINS); do \
+	    install -d $(DESTDIR)/$(DROPIN_DIR)/system/$${dropin}.d ;\
+	    install -m 0644 vm-systemd/$${dropin}.d/*.conf $(DESTDIR)/$(DROPIN_DIR)/system/$${dropin}.d/ ;\
 	done
 
 install-systemd:

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,10 @@ SYSTEM_DROPINS += NetworkManager.service NetworkManager-wait-online.service ntpd
 SYSTEM_DROPINS += tmp.mount
 SYSTEM_DROPINS += org.cups.cupsd.service org.cups.cupsd.path org.cups.cupsd.socket 
 
-# Debian System Dropins
+# Fedora User Dropins
+USER_DROPINS := pulseaudio.service pulseaudio.socket
+
+# Debian Dropins
 ifeq ($(shell lsb_release -is), Debian)
     # Don't have 'ntpd' in Debian
     SYSTEM_DROPINS := $(filter-out ntpd.service, $(SYSTEM_DROPINS))
@@ -74,6 +77,12 @@ install-systemd-dropins:
 	@for dropin in $(SYSTEM_DROPINS); do \
 	    install -d $(DESTDIR)/$(DROPIN_DIR)/system/$${dropin}.d ;\
 	    install -m 0644 vm-systemd/$${dropin}.d/*.conf $(DESTDIR)/$(DROPIN_DIR)/system/$${dropin}.d/ ;\
+	done
+	
+	# Install user dropins
+	@for dropin in $(USER_DROPINS); do \
+	    install -d $(DESTDIR)/$(DROPIN_DIR)/user/$${dropin}.d ;\
+	    install -m 0644 vm-systemd/user/$${dropin}.d/*.conf $(DESTDIR)/$(DROPIN_DIR)/user/$${dropin}.d/ ;\
 	done
 
 install-systemd:

--- a/rpm_spec/core-vm.spec
+++ b/rpm_spec/core-vm.spec
@@ -517,6 +517,9 @@ The Qubes core startup configuration for SystemD init.
 /lib/systemd/system/cups.service.d/30_qubes.conf
 /lib/systemd/system/cups.socket.d/30_qubes.conf
 /lib/systemd/system/cups.path.d/30_qubes.conf
+/lib/systemd/system/org.cups.cupsd.service.d/30_qubes.conf
+/lib/systemd/system/org.cups.cupsd.socket.d/30_qubes.conf
+/lib/systemd/system/org.cups.cupsd.path.d/30_qubes.conf
 /lib/systemd/system/getty@tty.service.d/30_qubes.conf
 /lib/systemd/system/ModemManager.service.d/30_qubes.conf
 /lib/systemd/system/NetworkManager.service.d/30_qubes.conf

--- a/rpm_spec/core-vm.spec
+++ b/rpm_spec/core-vm.spec
@@ -526,6 +526,8 @@ The Qubes core startup configuration for SystemD init.
 /lib/systemd/system/NetworkManager-wait-online.service.d/30_qubes.conf
 /lib/systemd/system/ntpd.service.d/30_qubes.conf
 /lib/systemd/system/tmp.mount.d/30_qubes.conf
+/lib/systemd/user/pulseaudio.service.d/30_qubes.conf
+/lib/systemd/user/pulseaudio.socket.d/30_qubes.conf
 
 %post systemd
 

--- a/vm-systemd/org.cups.cupsd.path.d/30_qubes.conf
+++ b/vm-systemd/org.cups.cupsd.path.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/var/run/qubes-service/cups

--- a/vm-systemd/org.cups.cupsd.service.d/30_qubes.conf
+++ b/vm-systemd/org.cups.cupsd.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/var/run/qubes-service/cups

--- a/vm-systemd/org.cups.cupsd.socket.d/30_qubes.conf
+++ b/vm-systemd/org.cups.cupsd.socket.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/var/run/qubes-service/cups

--- a/vm-systemd/user/pulseaudio.service.d/30_qubes.conf
+++ b/vm-systemd/user/pulseaudio.service.d/30_qubes.conf
@@ -1,0 +1,4 @@
+[Unit]
+#ConditionNull=false
+ConditionPathExists=/var/run/qubes-service/pulseaudio-vanilla-broken
+

--- a/vm-systemd/user/pulseaudio.socket.d/30_qubes.conf
+++ b/vm-systemd/user/pulseaudio.socket.d/30_qubes.conf
@@ -1,0 +1,4 @@
+[Unit]
+#ConditionNull=false
+ConditionPathExists=/var/run/qubes-service/pulseaudio-vanilla-broken
+


### PR DESCRIPTION
- Archlinux: build successfully and makes sound working in Qubes R3
- Fedora: build successfully but untested
- Debian: building not performed / testing not performed