### PR TITLE
No longer start /etc/init.d/tinyproxy by default anymore.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ DROPIN_DIR ?= "lib/systemd"
 # Fedora System Dropins
 SYSTEM_DROPINS := chronyd.service crond.service cups.service cups.path cups.socket ModemManager.service
 SYSTEM_DROPINS += NetworkManager.service NetworkManager-wait-online.service ntpd.service getty@tty.service
+SYSTEM_DROPINS += tinyproxy.service
 SYSTEM_DROPINS += tmp.mount
 SYSTEM_DROPINS += org.cups.cupsd.service org.cups.cupsd.path org.cups.cupsd.socket 
 
@@ -78,7 +79,7 @@ install-systemd-dropins:
 	    install -d $(DESTDIR)/$(DROPIN_DIR)/system/$${dropin}.d ;\
 	    install -m 0644 vm-systemd/$${dropin}.d/*.conf $(DESTDIR)/$(DROPIN_DIR)/system/$${dropin}.d/ ;\
 	done
-	
+
 	# Install user dropins
 	@for dropin in $(USER_DROPINS); do \
 	    install -d $(DESTDIR)/$(DROPIN_DIR)/user/$${dropin}.d ;\

--- a/rpm_spec/core-vm.spec
+++ b/rpm_spec/core-vm.spec
@@ -525,6 +525,7 @@ The Qubes core startup configuration for SystemD init.
 /lib/systemd/system/NetworkManager.service.d/30_qubes.conf
 /lib/systemd/system/NetworkManager-wait-online.service.d/30_qubes.conf
 /lib/systemd/system/ntpd.service.d/30_qubes.conf
+/lib/systemd/system/tinyproxy.service.d/30_not_needed_in_qubes_by_default.conf
 /lib/systemd/system/tmp.mount.d/30_qubes.conf
 /lib/systemd/user/pulseaudio.service.d/30_qubes.conf
 /lib/systemd/user/pulseaudio.socket.d/30_qubes.conf

--- a/vm-systemd/tinyproxy.service.d/30_not_needed_in_qubes_by_default.conf
+++ b/vm-systemd/tinyproxy.service.d/30_not_needed_in_qubes_by_default.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/var/run/qubes-service/tinyproxy


### PR DESCRIPTION
But allow users to re-enable it through qubes-service framework.
/var/run/qubes-service/tinyproxy

Thanks to @marmarek for helping with this fix!

https://github.com/QubesOS/qubes-issues/issues/1401