### PR TITLE
Allow to provide customized DispVM home directly in the template VM

### DIFF
--- a/misc/dispvm-prerun.sh
+++ b/misc/dispvm-prerun.sh
@@ -3,10 +3,12 @@
 apps="/usr/libexec/evinced"
 
 #If user have customized DispVM settings, use its home instead of default dotfiles
-if [ -e /rw/home/user/.qubes-dispvm-customized ]; then
-	cp -af /rw/home/user /home/
-else
-	cat /etc/dispvm-dotfiles.tbz | tar -xjf- --overwrite -C /home/user --owner user 2>&1 >/tmp/dispvm-dotfiles-errors.log
+if [ ! -e /home/user/.qubes-dispvm-customized ]; then
+	if [ -e /rw/home/user/.qubes-dispvm-customized ]; then
+		cp -af /rw/home/user /home/
+	else
+		cat /etc/dispvm-dotfiles.tbz | tar -xjf- --overwrite -C /home/user --owner user 2>&1 >/tmp/dispvm-dotfiles-errors.log
+	fi
 fi
 
 for app in $apps ; do

--- a/vm-systemd/mount-dirs.sh
+++ b/vm-systemd/mount-dirs.sh
@@ -79,10 +79,12 @@ if [ -e /var/run/qubes-service/qubes-dvm ]; then
     touch /etc/this-is-dvm
 
     #If user have customized DispVM settings, use its home instead of default dotfiles
-    if [ -e /rw/home/user/.qubes-dispvm-customized ]; then
-        cp -af /rw/home/user /home/
-    else
-        cat /etc/dispvm-dotfiles.tbz | tar -xjf- --overwrite -C /home/user --owner user 2>&1 >/tmp/dispvm-dotfiles-errors.log
+    if [ ! -e /home/user/.qubes-dispvm-customized ]; then
+        if [ -e /rw/home/user/.qubes-dispvm-customized ]; then
+            cp -af /rw/home/user /home/
+        else
+            cat /etc/dispvm-dotfiles.tbz | tar -xjf- --overwrite -C /home/user --owner user 2>&1 >/tmp/dispvm-dotfiles-errors.log
+        fi
     fi
 else
     mount /home


### PR DESCRIPTION
This allows to put a customized DispVM home directly in /home_volatile in the template instead of placing it in the -dvm internal AppVM.

This significantly speeds up DispVM startup for large customized homes, since none of the home data has to be copied out from saved_cows.tar to volatile.img, and instead CoW is used.

It's not a very user friendly or discoverable solution, but it only takes a few lines of code, and so seems a reasonable stopgap until a much more complex solution with copy-on-write for the private.img is written.

BTW: I'm confused by the fact that home copying is being done in two places: is this correct? Why is the repetition necessary?
