### PR TITLE
Prevent services from being accidentally restarted by `needrestart`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,9 @@ install-common:
 	install -D -m 0440 misc/sudoers.d_qt_x11_no_mitshm $(DESTDIR)/etc/sudoers.d/qt_x11_no_mitshm
 	install -D -m 0644 misc/20_tcp_timestamps.conf $(DESTDIR)/etc/sysctl.d/20_tcp_timestamps.conf
 
+	install -d $(DESTDIR)/etc/needrestart/conf.d
+	install -D -m 0644 misc/50_qubes.conf $(DESTDIR)/etc/needrestart/conf.d/50_qubes.conf
+
 	install -d $(DESTDIR)/var/lib/qubes
 
 	install -D misc/xenstore-watch $(DESTDIR)/usr/bin/xenstore-watch-qubes

--- a/misc/50_qubes.conf
+++ b/misc/50_qubes.conf
@@ -1,0 +1,2 @@
+$nrconf{override_rc}->{q(^qubes-core-agent-linux)} = 0;
+$nrconf{override_rc}->{q(^qubes-gui-agent)} = 0;


### PR DESCRIPTION
Because those services do not yet support being restarted.

Extended variable `$nrconf{override_rc}`, i.e. packages only reported to need
restart, but blacklisted from default/suggested automatic restarted with
`qubes-core-agent` and `qubes-gui-agent`.

See also `$nrconf{override_rc}`:
https://github.com/liske/needrestart/blob/10bd2db5e2d88370882cb74d729392f5a1389098/ex/needrestart.conf#L65

Thanks to @liske for helping with this.
https://github.com/liske/needrestart/issues/13#issuecomment-136804625