### PR TITLE
Remove dangling reference to filter-updates file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,6 @@ install-common:
 		$(DESTDIR)/etc/NetworkManager/conf.d/30-qubes.conf
 	install -D network/vif-route-qubes $(DESTDIR)/etc/xen/scripts/vif-route-qubes
 	install -m 0644 -D network/tinyproxy-updates.conf $(DESTDIR)/etc/tinyproxy/tinyproxy-updates.conf
-	install -m 0644 -D network/filter-updates $(DESTDIR)/etc/tinyproxy/filter-updates
 	install -m 0755 -D network/iptables-updates-proxy $(DESTDIR)$(LIBDIR)/qubes/iptables-updates-proxy
 	install -d $(DESTDIR)/etc/xdg/autostart
 	install -m 0755 network/show-hide-nm-applet.sh $(DESTDIR)$(LIBDIR)/qubes/show-hide-nm-applet.sh


### PR DESCRIPTION
This seemed to be tripping up building v3.1.4, at least with the Archlinux template.  It looks like the relevant file was axed in 69bb71bea006220ff17117f5b319cbbc2a87e918