### PR TITLE
[network-proxy-setup] Explicitly handle !CONFIG_MODULES

### DIFF
--- a/vm-systemd/network-proxy-setup.sh
+++ b/vm-systemd/network-proxy-setup.sh
@@ -3,10 +3,17 @@
 # Setup gateway for all the VMs this netVM is serviceing...
 network=$(qubesdb-read /qubes-netvm-network 2>/dev/null)
 if [ "x$network" != "x" ]; then
+
+    if [ -e /proc/sys/kernel ] && ! [ -e /proc/sys/kernel/modules_disabled ]; then
+      readonly modprobe_fail_cmd='true'
+    else
+      readonly modprobe_fail_cmd='false'
+    fi
+
     gateway=$(qubesdb-read /qubes-netvm-gateway)
     netmask=$(qubesdb-read /qubes-netvm-netmask)
     secondary_dns=$(qubesdb-read /qubes-netvm-secondary-dns)
-    modprobe netbk 2> /dev/null || modprobe xen-netback
+    modprobe netbk 2> /dev/null || modprobe xen-netback || "${modprobe_fail_cmd}"
     echo "NS1=$gateway" > /var/run/qubes/qubes-ns
     echo "NS2=$secondary_dns" >> /var/run/qubes/qubes-ns
     /usr/lib/qubes/qubes-setup-dnat-to-ns


### PR DESCRIPTION
Whonix sets -e and subsequently shuts down the vm on modprobe failure, presumably to prevent network leaks otherwise closed later on.

Since other templates don't do the same, I don't know whether it's appropriate to apply this change outside Whonix, but @adrelanos suggested consideration.

> * Check whether sysctl is accessible
> * Check whether a key which exists when CONFIG_MODULES=y is not accessible
> 
> If true, CONFIG_MODULES=n, so ignore modprobe failure.
> If false, fail.