### PR TITLE
archlinux: ensure systemctl reset preset correctly 

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -6,7 +6,7 @@
 # Maintainer: Olivier Medoc <o_medoc@yahoo.fr>
 pkgname=qubes-vm-core
 pkgver=`cat version`
-pkgrel=1
+pkgrel=2
 epoch=
 pkgdesc="The Qubes core files for installation inside a Qubes VM."
 arch=("x86_64")

--- a/archlinux/PKGBUILD.install
+++ b/archlinux/PKGBUILD.install
@@ -151,13 +151,18 @@ configure_systemd() {
 PRESET_FAILED=0
 
 if [ $1 -eq 1 ]; then
-    systemctl --no-reload preset-all > /dev/null 2>&1 && PRESET_FAILED=0 || PRESET_FAILED=1
+    # Needs to be started two times to deal  with services name changes (systemctl bug?)
+    echo "Resetting systemd services to defaults presets (PASS 1)"
+    systemctl --no-reload preset-all 2>&1 && PRESET_FAILED=0 || PRESET_FAILED=1
+    echo "Resetting systemd services to defaults presets (PASS 2)"
+    systemctl --no-reload preset-all 2>&1 && PRESET_FAILED=0 || PRESET_FAILED=1
 else
     services="qubes-dvm qubes-misc-post qubes-firewall qubes-mount-dirs"
     services="$services qubes-netwatcher qubes-network qubes-sysinit"
     services="$services qubes-iptables qubes-updates-proxy qubes-qrexec-agent"
     services="$services qubes-random-seed"
     for srv in $services; do
+        echo "Enable service defaults for $service"
         systemctl --no-reload preset $srv.service
     done
     systemctl --no-reload preset qubes-update-check.timer


### PR DESCRIPTION
(systemd preset need to be started twice when systemd services names are changed... cd qubes-core-agent vs qubes-qrexec-agent - One pass for disabling the old service that doesn't exists anymore, one pass for reenabling the service).

I don't know if it is a systemd bug.
