### PR TITLE
do not start the Tor service inside Qubes TemplateVMs

### DIFF
--- a/vm-systemd/tor.service.d/30_qubes.conf
+++ b/vm-systemd/tor.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=!/var/run/qubes/this-is-templatevm


### PR DESCRIPTION
Private data inside /var/lib/tor should not be shared.
Tor should not be run inside TemplateVMs.

https://github.com/QubesOS/qubes-issues/issues/1625#issuecomment-172369781