### PR TITLE
systemd: order units checking for qubes-service after qubes-sysinit

### DIFF
--- a/vm-systemd/ModemManager.service.d/30_qubes.conf
+++ b/vm-systemd/ModemManager.service.d/30_qubes.conf
@@ -1,3 +1,4 @@
 [Unit]
 ConditionPathExists=|/var/run/qubes-service/network-manager
 ConditionPathExists=|/var/run/qubes-service/modem-manager
+After=qubes-sysinit.service

--- a/vm-systemd/NetworkManager-wait-online.service.d/30_qubes.conf
+++ b/vm-systemd/NetworkManager-wait-online.service.d/30_qubes.conf
@@ -1,4 +1,4 @@
 [Unit]
 ConditionPathExists=/var/run/qubes-service/network-manager
 # For /rw
-After=qubes-misc-post.service
+After=qubes-misc-post.service qubes-sysinit.service

--- a/vm-systemd/NetworkManager.service.d/30_qubes.conf
+++ b/vm-systemd/NetworkManager.service.d/30_qubes.conf
@@ -1,7 +1,7 @@
 [Unit]
 ConditionPathExists=/var/run/qubes-service/network-manager
 # For /rw
-After=qubes-misc-post.service
+After=qubes-misc-post.service qubes-sysinit.service
 
 [Service]
 ExecStartPre=/usr/lib/qubes/network-manager-prepare-conf-dir

--- a/vm-systemd/chronyd.service.d/30_qubes.conf
+++ b/vm-systemd/chronyd.service.d/30_qubes.conf
@@ -1,2 +1,3 @@
 [Unit]
 ConditionPathExists=/var/run/qubes-service/ntpd
+After=qubes-sysinit.service

--- a/vm-systemd/cron.service.d/30_qubes.conf
+++ b/vm-systemd/cron.service.d/30_qubes.conf
@@ -3,7 +3,7 @@ ConditionPathExists=/var/run/qubes-service/crond
 
 [Unit]
 # For /rw
-After=qubes-misc-post.service
+After=qubes-misc-post.service qubes-sysinit.service
 
 [Service]
 ExecStartPre=/bin/mkdir --mode=0700 -p /rw/cron

--- a/vm-systemd/crond.service.d/30_qubes.conf
+++ b/vm-systemd/crond.service.d/30_qubes.conf
@@ -3,7 +3,7 @@ ConditionPathExists=/var/run/qubes-service/crond
 
 [Unit]
 # For /rw
-After=qubes-misc-post.service
+After=qubes-misc-post.service qubes-sysinit.service
 
 [Service]
 ExecStartPre=/bin/mkdir --mode=0700 -p /rw/cron

--- a/vm-systemd/cups.path.d/30_qubes.conf
+++ b/vm-systemd/cups.path.d/30_qubes.conf
@@ -1,2 +1,3 @@
 [Unit]
 ConditionPathExists=/var/run/qubes-service/cups
+After=qubes-sysinit.service

--- a/vm-systemd/cups.service.d/30_qubes.conf
+++ b/vm-systemd/cups.service.d/30_qubes.conf
@@ -1,2 +1,3 @@
 [Unit]
 ConditionPathExists=/var/run/qubes-service/cups
+After=qubes-sysinit.service

--- a/vm-systemd/cups.socket.d/30_qubes.conf
+++ b/vm-systemd/cups.socket.d/30_qubes.conf
@@ -1,2 +1,3 @@
 [Unit]
 ConditionPathExists=/var/run/qubes-service/cups
+After=qubes-sysinit.service

--- a/vm-systemd/getty@tty.service.d/30_qubes.conf
+++ b/vm-systemd/getty@tty.service.d/30_qubes.conf
@@ -1,2 +1,3 @@
 [Unit]
 ConditionPathExists=/var/run/qubes-service/getty@tty
+After=qubes-sysinit.service

--- a/vm-systemd/netfilter-persistent.service.d/30_qubes.conf
+++ b/vm-systemd/netfilter-persistent.service.d/30_qubes.conf
@@ -1,2 +1,3 @@
 [Unit]
 ConditionPathExists=/var/run/qubes-service/netfilter-persistent
+After=qubes-sysinit.service

--- a/vm-systemd/network-manager.service.d/30_qubes.conf
+++ b/vm-systemd/network-manager.service.d/30_qubes.conf
@@ -1,3 +1,4 @@
 # Disable sysinit version of network-manager (wheezy)
 [Unit]
 ConditionPathExists=!/var/run/qubes-service
+After=qubes-sysinit.service

--- a/vm-systemd/ntpd.service.d/30_qubes.conf
+++ b/vm-systemd/ntpd.service.d/30_qubes.conf
@@ -1,2 +1,3 @@
 [Unit]
 ConditionPathExists=/var/run/qubes-service/ntpd
+After=qubes-sysinit.service

--- a/vm-systemd/org.cups.cupsd.path.d/30_qubes.conf
+++ b/vm-systemd/org.cups.cupsd.path.d/30_qubes.conf
@@ -1,2 +1,3 @@
 [Unit]
 ConditionPathExists=/var/run/qubes-service/cups
+After=qubes-sysinit.service

--- a/vm-systemd/org.cups.cupsd.service.d/30_qubes.conf
+++ b/vm-systemd/org.cups.cupsd.service.d/30_qubes.conf
@@ -1,2 +1,3 @@
 [Unit]
 ConditionPathExists=/var/run/qubes-service/cups
+After=qubes-sysinit.service

--- a/vm-systemd/org.cups.cupsd.socket.d/30_qubes.conf
+++ b/vm-systemd/org.cups.cupsd.socket.d/30_qubes.conf
@@ -1,2 +1,3 @@
 [Unit]
 ConditionPathExists=/var/run/qubes-service/cups
+After=qubes-sysinit.service

--- a/vm-systemd/tor.service.d/30_qubes.conf
+++ b/vm-systemd/tor.service.d/30_qubes.conf
@@ -1,2 +1,3 @@
 [Unit]
 ConditionPathExists=!/var/run/qubes/this-is-templatevm
+After=qubes-sysinit.service


### PR DESCRIPTION
Files in /var/run/qubes-service are created by qubes-sysinit.service. So
defer that condition check after that service start.

Thanks @adrelanos for the report.

Fixes QubesOS/qubes-issues#1985