### PR TITLE
Configure NetworkManager to keep /etc/resolv.conf as plain file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,8 @@ install-common:
 	ln -s /usr/lib/qubes/qubes-setup-dnat-to-ns $(DESTDIR)/etc/dhclient.d/qubes-setup-dnat-to-ns.sh
 	install -d $(DESTDIR)/etc/NetworkManager/dispatcher.d/
 	install network/{qubes-nmhook,30-qubes-external-ip} $(DESTDIR)/etc/NetworkManager/dispatcher.d/
+	install -d $(DESTDIR)/usr/lib/NetworkManager/conf.d
+	install -m 0644 network/nm-30-qubes.conf $(DESTDIR)/usr/lib/NetworkManager/conf.d/30-qubes.conf
 	install -D network/vif-route-qubes $(DESTDIR)/etc/xen/scripts/vif-route-qubes
 	install -m 0644 -D network/tinyproxy-updates.conf $(DESTDIR)/etc/tinyproxy/tinyproxy-updates.conf
 	install -m 0644 -D network/updates-blacklist $(DESTDIR)/etc/tinyproxy/updates-blacklist

--- a/network/nm-30-qubes.conf
+++ b/network/nm-30-qubes.conf
@@ -1,0 +1,2 @@
+[main]
+rc-manager=file

--- a/rpm_spec/core-vm.spec
+++ b/rpm_spec/core-vm.spec
@@ -424,6 +424,7 @@ rm -f %{name}-%{version}
 /usr/lib/qubes/upgrades-status-notify
 /usr/lib/yum-plugins/yum-qubes-hooks.py*
 /usr/lib/dracut/dracut.conf.d/30-qubes.conf
+/usr/lib/NetworkManager/conf.d/30-qubes.conf
 /usr/lib64/python2.7/site-packages/qubes/xdg.py*
 /usr/sbin/qubes-firewall
 /usr/sbin/qubes-netwatcher


### PR DESCRIPTION
Do not use a symlink there, as it will be left after NetworkManager
shutdown - as a broken link then

Fixes QubesOS/qubes-issues#2320
Reported by Achim Patzner <noses@noses.com>